### PR TITLE
Add permissions required to Terraform ParameterStoreReadOnly-* roles and policies

### DIFF
--- a/provisionparameterstorereadroles_policy.tf
+++ b/provisionparameterstorereadroles_policy.tf
@@ -7,17 +7,34 @@
 data "aws_iam_policy_document" "provisionparameterstorereadroles_doc" {
   statement {
     actions = [
+      "iam:AttachRolePolicy",
       "iam:CreateRole",
       "iam:DeleteRole",
       "iam:DeleteRolePolicy",
+      "iam:DetachRolePolicy",
       "iam:GetRole",
       "iam:GetRolePolicy",
+      "iam:ListAttachedRolePolicies",
       "iam:ListInstanceProfilesForRole",
       "iam:PutRolePolicy",
+      "iam:TagRole",
       "iam:UpdateRole"
     ]
     resources = [
       "arn:aws:iam::${var.images_account_id}:role/ParameterStoreReadOnly-*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "iam:CreatePolicy",
+      "iam:DeletePolicy",
+      "iam:GetPolicy",
+      "iam:GetPolicyVersion",
+      "iam:ListPolicyVersions"
+    ]
+    resources = [
+      "arn:aws:iam::${var.images_account_id}:policy/ParameterStoreReadOnly-*"
     ]
   }
 }


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds some additional permissions that are needed in order to successfully create/modify/destroy `ParameterStoreReadOnly-*` roles and policies.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
Without these permissions, the `ProvisionParameterStoreReadRoles` role does not function as intended.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

This change was tested by adding the new permissions to the `ProvisionParameterStoreReadRoles` role in Production and confirming that the example Terraform code in `molecule-packer-ci-iam-user-tf-module` was able to successfully create a test `ParameterStoreReadRole-*` role.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
