### PR TITLE
Get account ID from the provider's caller identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ access in the COOL Images account.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-------:|:--------:|
 | aws_region | The AWS region where the non-global resources are to be provisioned (e.g. "us-east-1"). | string | `us-east-1` | no |
-| images_account_id | The ID of the images account. | string | | yes |
 | parameterstorefullaccess_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows full access to SSM ParameterStore. | string | `Allows full access to SSM ParameterStore.` | no |
 | parameterstorefullaccess_role_name | The name to assign the IAM role (as well as the corresponding policy) that allows full access to SSM ParameterStore. | string | `ParameterStoreFullAccess` | no |
 | parameterstorereadonly_role_description | The description to associate with the IAM role (as well as the corresponding policy) that allows read-only access to SSM ParameterStore. | string | `Allows read-only access to SSM ParameterStore.` | no |

--- a/caller_identity.tf
+++ b/caller_identity.tf
@@ -1,0 +1,6 @@
+# ------------------------------------------------------------------------------
+# We can get the account ID of the Images account from the provider's
+# caller identity.
+# ------------------------------------------------------------------------------
+data "aws_caller_identity" "images" {
+}

--- a/parameterstorefullaccess_policy.tf
+++ b/parameterstorefullaccess_policy.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "parameterstorefullaccess_doc" {
       "ssm:PutParameter"
     ]
     resources = [
-      "arn:aws:ssm:*:${var.images_account_id}:parameter/*",
+      "arn:aws:ssm:*:${data.aws_caller_identity.images.account_id}:parameter/*",
     ]
   }
 

--- a/parameterstorereadonly_policy.tf
+++ b/parameterstorereadonly_policy.tf
@@ -10,7 +10,7 @@ data "aws_iam_policy_document" "parameterstorereadonly_doc" {
       "ssm:GetParameters"
     ]
     resources = [
-      "arn:aws:ssm:*:${var.images_account_id}:parameter/*",
+      "arn:aws:ssm:*:${data.aws_caller_identity.images.account_id}:parameter/*",
     ]
   }
 }

--- a/provisionparameterstorereadroles_policy.tf
+++ b/provisionparameterstorereadroles_policy.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "provisionparameterstorereadroles_doc" {
       "iam:UpdateRole"
     ]
     resources = [
-      "arn:aws:iam::${var.images_account_id}:role/ParameterStoreReadOnly-*"
+      "arn:aws:iam::${data.aws_caller_identity.images.account_id}:role/ParameterStoreReadOnly-*"
     ]
   }
 
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "provisionparameterstorereadroles_doc" {
       "iam:ListPolicyVersions"
     ]
     resources = [
-      "arn:aws:iam::${var.images_account_id}:policy/ParameterStoreReadOnly-*"
+      "arn:aws:iam::${data.aws_caller_identity.images.account_id}:policy/ParameterStoreReadOnly-*"
     ]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,10 +4,6 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
-variable "images_account_id" {
-  description = "The ID of the images account."
-}
-
 variable "users_account_id" {
   description = "The ID of the users account."
 }


### PR DESCRIPTION
## 🗣 Description

In this pull request we get the Images account ID from the provider instead of passing it in as an input parameter.

## 💭 Motivation and Context

This results in one less input parameter.

## 🧪 Testing

I ran a `terraform apply` with these changes and verified that terraform does not want to make any changes.  I also verified that all the pre-commit hooks pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
