### PR TITLE
Specify the string type for variables

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,7 @@
 # ------------------------------------------------------------------------------
 
 variable "users_account_id" {
+  type        = string
   description = "The ID of the users account."
 }
 
@@ -15,36 +16,43 @@ variable "users_account_id" {
 # ------------------------------------------------------------------------------
 
 variable "aws_region" {
+  type        = string
   description = "The AWS region where the non-global resources are to be provisioned (e.g. \"us-east-1\")."
   default     = "us-east-1"
 }
 
 variable "parameterstorefullaccess_role_description" {
+  type        = string
   description = "The description to associate with the IAM role (as well as the corresponding policy) that allows full access to SSM ParameterStore."
   default     = "Allows full access to SSM ParameterStore."
 }
 
 variable "parameterstorefullaccess_role_name" {
+  type        = string
   description = "The name to assign the IAM role (as well as the corresponding policy) that allows full access to SSM ParameterStore."
   default     = "ParameterStoreFullAccess"
 }
 
 variable "parameterstorereadonly_role_description" {
+  type        = string
   description = "The description to associate with the IAM role (as well as the corresponding policy) that allows read-only access to SSM ParameterStore."
   default     = "Allows read-only access to SSM ParameterStore."
 }
 
 variable "parameterstorereadonly_role_name" {
+  type        = string
   description = "The name to assign the IAM role (as well as the corresponding policy) that allows read-only access to SSM ParameterStore."
   default     = "ParameterStoreReadOnly"
 }
 
 variable "provisionparameterstorereadroles_role_description" {
+  type        = string
   description = "The description to associate with the IAM role (as well as the corresponding policy) with the ability to create IAM roles that can read selected ParameterStore parameters in the Images account."
   default     = "Allows creation of IAM roles that can read selected ParameterStore parameters in the Images account."
 }
 
 variable "provisionparameterstorereadroles_role_name" {
+  type        = string
   description = "The name to assign the IAM role (as well as the corresponding policy) with the ability to create IAM roles that can read selected ParameterStore parameters in the Images account."
   default     = "ProvisionParameterStoreReadRoles"
 }


### PR DESCRIPTION
## 🗣 Description

Previously string was the default type, but this is [no longer the case](https://www.terraform.io/docs/configuration/variables.html#type-constraints).

I ran into a case today where this mattered.  I used `set([var.string_value])` in a `for_each`, and Terraform rejected the syntax since it couldn't verify that the output would be a set of strings.  Adding the string type declaration to the variable fixed the issue.

## 💭 Motivation and Context

This change makes the code more correct, and it will avoid subtle errors like the one I saw today.

## 🧪 Testing

I ran a `terraform apply` and verified that nothing needed to be changed.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
