### PR TITLE
Add missing permission

### DIFF
--- a/provisionparameterstorereadroles_policy.tf
+++ b/provisionparameterstorereadroles_policy.tf
@@ -19,7 +19,8 @@ data "aws_iam_policy_document" "provisionparameterstorereadroles_doc" {
       "iam:PutRolePolicy",
       "iam:TagRole",
       "iam:UpdateAssumeRolePolicy",
-      "iam:UpdateRole"
+      "iam:UpdateRole",
+      "iam:UpdateRoleDescription",
     ]
     resources = [
       "arn:aws:iam::${data.aws_caller_identity.images.account_id}:role/ParameterStoreReadOnly-*"


### PR DESCRIPTION
## 🗣 Description

This pull request adds a missing permission (`iam:UpdateRoleDescription`) to the `ProvisionParameterStoreReadRoles` policy.

## 💭 Motivation and Context

I encountered a case where I was unable to update a role in place because of this missing permission.

## 🧪 Testing

I deployed this change to COOL staging and verified that this change fixes the error I encountered.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
