### PR TITLE
Add a missing permission

### DIFF
--- a/provisionparameterstorereadroles_policy.tf
+++ b/provisionparameterstorereadroles_policy.tf
@@ -16,6 +16,7 @@ data "aws_iam_policy_document" "provisionparameterstorereadroles_doc" {
       "iam:GetRolePolicy",
       "iam:ListAttachedRolePolicies",
       "iam:ListInstanceProfilesForRole",
+      "iam:ListRolePolicies",
       "iam:PutRolePolicy",
       "iam:TagRole",
       "iam:UpdateAssumeRolePolicy",


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a necessary, but previously missing, permission to a policy.

## 💭 Motivation and context ##

Something changed recently either with the AWS Terraform provider or with AWS itself, and now this permission is needed.  I encountered this when attempting to `terraform destroy` some previously-created resources.

This PR is very similar to https://github.com/cisagov/cool-accounts/pull/76 and https://github.com/cisagov/cool-dns-certboto/pull/18.

## 🧪 Testing ##

This change has been applied to the production and staging "Images" accounts.  I confirmed the error that I previously saw went away and I was able to successfully destroy the assessment environment that I needed to.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
